### PR TITLE
Updating Markov Chain

### DIFF
--- a/model/mergedODE.ecore
+++ b/model/mergedODE.ecore
@@ -349,8 +349,12 @@
     <eClassifiers xsi:type="ecore:EClass" name="MarkovChain" eSuperTypes="#//failureLogic/FailureModel">
       <eStructuralFeatures xsi:type="ecore:EReference" name="transitions" upperBound="-1"
           eType="#//failureLogic/Transition" containment="true"/>
+      <eStructuralFeatures xsi:type="ecore:EReference" name="transitionMatrices" upperBound="-1"
+          eType="#//failureLogic/TransitionMatrix" containment="true"/>
       <eStructuralFeatures xsi:type="ecore:EReference" name="states" upperBound="-1"
           eType="#//failureLogic/State" containment="true"/>
+      <eStructuralFeatures xsi:type="ecore:EReference" name="initialProbability" eType="#//failureLogic/ProbDist"
+          containment="true"/>
     </eClassifiers>
     <eClassifiers xsi:type="ecore:EClass" name="State" eSuperTypes="#//odeBase/BaseElement">
       <eStructuralFeatures xsi:type="ecore:EAttribute" name="isInitialState" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean"/>
@@ -358,13 +362,27 @@
       <eStructuralFeatures xsi:type="ecore:EReference" name="failState" eType="#//failureLogic/Failure"/>
     </eClassifiers>
     <eClassifiers xsi:type="ecore:EClass" name="Transition" eSuperTypes="#//odeBase/BaseElement">
-      <eStructuralFeatures xsi:type="ecore:EAttribute" name="transition" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EDouble"/>
+      <eStructuralFeatures xsi:type="ecore:EAttribute" name="transitionRate" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EDouble"/>
       <eStructuralFeatures xsi:type="ecore:EReference" name="transitionProbDistribution"
           eType="#//failureLogic/ProbDist" containment="true"/>
+      <eStructuralFeatures xsi:type="ecore:EReference" name="failure" eType="#//failureLogic/Failure"/>
       <eStructuralFeatures xsi:type="ecore:EReference" name="fromStates" upperBound="-1"
           eType="#//failureLogic/State"/>
       <eStructuralFeatures xsi:type="ecore:EReference" name="toStates" upperBound="-1"
           eType="#//failureLogic/State"/>
+    </eClassifiers>
+    <eClassifiers xsi:type="ecore:EClass" name="TransitionMatrix" eSuperTypes="#//odeBase/BaseElement">
+      <eStructuralFeatures xsi:type="ecore:EReference" name="rows" upperBound="-1"
+          eType="#//failureLogic/TransitionRowEntry" containment="true"/>
+    </eClassifiers>
+    <eClassifiers xsi:type="ecore:EClass" name="TransitionRowEntry">
+      <eStructuralFeatures xsi:type="ecore:EReference" name="fromState" eType="#//failureLogic/State"/>
+      <eStructuralFeatures xsi:type="ecore:EReference" name="colEntries" upperBound="-1"
+          eType="#//failureLogic/TransitionColEntry" containment="true"/>
+    </eClassifiers>
+    <eClassifiers xsi:type="ecore:EClass" name="TransitionColEntry">
+      <eStructuralFeatures xsi:type="ecore:EReference" name="failure" eType="#//failureLogic/Failure"/>
+      <eStructuralFeatures xsi:type="ecore:EReference" name="toState" eType="#//failureLogic/State"/>
     </eClassifiers>
     <eClassifiers xsi:type="ecore:EEnum" name="FMEAType">
       <eLiterals name="FMEA"/>

--- a/model/mergedODE.emf
+++ b/model/mergedODE.emf
@@ -380,20 +380,36 @@ package failureLogic {
 
   class MarkovChain extends FailureModel {
     val Transition[*] transitions;
+    val TransitionMatrix[*] transitionMatrices;
     val State[*] states;
+    val ProbDist[1] initialProbability;
   }
 
   class State extends odeBase.BaseElement {
     attr boolean isInitialState;
-    attr boolean isFailState;
-    ref Failure failState;
+    ref Failure[1] failState;
   }
 
   class Transition extends odeBase.BaseElement {
-    attr double transition;
-    val ProbDist transitionProbDistribution;
-    ref State[*] fromStates;
-    ref State[*] toStates;
+    attr double transitionRate;
+    val ProbDist[1] transitionProbDistribution;
+    ref Failure[1] failure;
+    ref State fromState;
+    ref State toState;
+  }
+  
+  class TransitionMatrix extends odeBase.BaseElement {
+  	val TransitionRowEntry[*] rows;
+  }
+  
+  class TransitionRowEntry {
+  	ref State fromState;
+  	val TransitionColEntry[*] colEntries;
+  }
+  
+  class TransitionColEntry {
+  	ref Failure[1] failure;
+  	ref State toState;
   }
 
   enum FMEAType {


### PR DESCRIPTION
- Now supports initial state probability distribution
- Supports both graph-based and matrix-based (row-oriented) representation
- Transitions can now relate to Failures